### PR TITLE
Ignore anchors/queryparams when navigating

### DIFF
--- a/src/extensions/default/bramble/lib/LinkManager.js
+++ b/src/extensions/default/bramble/lib/LinkManager.js
@@ -16,7 +16,18 @@ define(function (require, exports, module) {
 
     function getNavigationPath(message) {
         var match = message.match(/^bramble-navigate\:(.+)/);
-        return match && match[1];
+        var navPath = match && match[1];
+        // TODO (Brad 2017-09-28): Replace with a complete fix.
+        // Partial support for links with anchors or queryparams - strip the
+        // anchor and queryparam portions of the URL entirely, allowing at
+        // least the navigation to succeed (where before we hit an error and
+        // took no action at all).
+        // The long-term solution is probably a change in LinkManagerRemote.js
+        // that handles anchors after successful navigation.
+        if (navPath) {
+            navPath = navPath.replace(/[#?].*$/, '');
+        }
+        return navPath;
     }
 
     // Whether or not this message is a navigation request from the LinkManagerRemote script.


### PR DESCRIPTION
A [recent helpdesk ticket][1] alerted us to a bug in bramble where navigation to certain urls fails - in particular, urls with anchors or query params.

```html
<!-- These work properly -->
<a href="page2.html">To page 2</a>
<a href="#end-of-page">To end of page 1</a>

<!-- These are broken -->
<a href="page2.html#end-of-page">End of page 2</a>
<a href="page2.html?q=a">Page 2 with queryparams</a>
```

In the broken cases the links are simply unresponsive - a message is generated in the browser console and no navigation occurs.  Note that these work fine in shared projects when we load the source normally and let the browser handle navigation.

Fixing these properly in the bramble editing environment (which has manual handlers for both navigation and anchors) is fairly involved, and we've scheduled it further out.  This commit is a partial mitigation that allows navigation to succeed for the currently failing cases, by completely ignoring the anchor and/or queryparam portions of the URL.

[1]: https://codeorg.zendesk.com/agent/tickets/110284