### PR TITLE
fixed setup instructions and updated CodeMirror submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/thirdparty/CodeMirror"]
 	path = src/thirdparty/CodeMirror
-	url = https://github.com/adobe/CodeMirror2.git
+	url = https://github.com/codemirror/CodeMirror.git
 [submodule "src/thirdparty/path-utils"]
 	path = src/thirdparty/path-utils
 	url = https://github.com/jblas/path-utils.git

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ for info on how we're using CodeMirror.
 
 # How to setup Bramble (Brackets) in your local machine
 
-Step 1: Make sure you fork and clone [Bramble](https://github.com/mozilla/brackets).
+Step 1: Make sure you clone our fork of [Bramble](https://github.com/mozilla/brackets) recursively.
 
 ```
-$ git clone https://github.com/[yourusername]/brackets --recursive
+$ git clone https://github.com/code-dot-org/bramble.git --recursive
 ```
 
 Step 2: Install its dependencies


### PR DESCRIPTION
The CodeMirror submodule had an outdated url, this fixes that url and clarifies the README instructions.
-[slack conversation](https://codedotorg.slack.com/archives/C0T0UQA7K/p1594309934040500)