### PR TITLE
updated invalid characters for filenames

### DIFF
--- a/locales/en-US/editor.properties
+++ b/locales/en-US/editor.properties
@@ -47,7 +47,7 @@ ERROR_DELETING_DIRECTORY=An error occurred when trying to delete the directory <
 INVALID_FILENAME_TITLE=Invalid File Name
 INVALID_DIRNAME_TITLE=Invalid Directory Name
 # {1} will be replaced with an error message
-INVALID_FILENAME_MESSAGE=File names cannot use any system reserved words, end with dots (.) or use any of the following characters: <code class='emphasized'>{1}</code>
+INVALID_FILENAME_MESSAGE=File names cannot use any system reserved words, end with dots (.), or use special characters other than the following characters: !-_.()
 # {1} will be replaced with an error message
 INVALID_DIRNAME_MESSAGE=Directory names cannot use any system reserved words, end with dots (.) or use any of the following characters: <code class='emphasized'>{1}</code>
 # {0} will be replaced with a filename

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -182,7 +182,7 @@ define(function (require, exports, module) {
             if (error === FileSystemError.ALREADY_EXISTS) {
                 _showErrorDialog(ERR_TYPE_CREATE_EXISTS, isFolder, null, name);
             } else if (error === ProjectModel.ERROR_INVALID_FILENAME) {
-                _showErrorDialog(ERR_TYPE_INVALID_FILENAME, isFolder, ProjectModel._invalidChars);
+                _showErrorDialog(ERR_TYPE_INVALID_FILENAME, isFolder);
             } else {
                 var errString = error === FileSystemError.NOT_WRITABLE ?
                         Strings.NO_MODIFICATION_ALLOWED_ERR :
@@ -607,7 +607,7 @@ define(function (require, exports, module) {
             break;
         case ERR_TYPE_INVALID_FILENAME:
             title = StringUtils.format(Strings[isFolder ? "INVALID_DIRNAME_TITLE" : "INVALID_FILENAME_TITLE"], isFolder ? Strings.DIRECTORY_NAME : Strings.FILENAME);
-            message = StringUtils.format(Strings[isFolder ? "INVALID_DIRNAME_MESSAGE" : "INVALID_FILENAME_MESSAGE"], isFolder ? Strings.DIRECTORY_NAMES_LEDE : Strings.FILENAMES_LEDE, error);
+            message = StringUtils.format(Strings[isFolder ? "INVALID_DIRNAME_MESSAGE" : "INVALID_FILENAME_MESSAGE"], isFolder ? Strings.DIRECTORY_NAMES_LEDE : Strings.FILENAMES_LEDE);
             break;
         }
 
@@ -1340,7 +1340,7 @@ define(function (require, exports, module) {
                 // is not displayed.
                 window.setTimeout(function () {
                     if (errorInfo.type === ProjectModel.ERROR_INVALID_FILENAME) {
-                        _showErrorDialog(ERR_TYPE_INVALID_FILENAME, errorInfo.isFolder, ProjectModel._invalidChars);
+                        _showErrorDialog(ERR_TYPE_INVALID_FILENAME, errorInfo.isFolder);
                     } else {
                         var errString = errorInfo.type === FileSystemError.ALREADY_EXISTS ?
                                 Strings.FILE_EXISTS_ERR :

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -22,7 +22,7 @@
  */
 
 /* unittests: ProjectModel */
-/*global define, brackets, $ */
+/*global define, $ */
 
 /**
  * Provides the data source for a project and manages the view model for the FileTreeView.
@@ -58,14 +58,6 @@ define(function (require, exports, module) {
      */
     var _exclusionListRegEx = /\.pyc$|^\.git$|^\.gitmodules$|^\.svn$|^\.DS_Store$|^Thumbs\.db$|^\.hg$|^CVS$|^\.hgtags$|^\.idea$|^\.c9revisions$|^\.SyncArchive$|^\.SyncID$|^\.SyncIgnore$|\~$/;
 
-    /**
-     * @private
-     * A string containing all invalid characters for a specific platform.
-     * This will be used to construct a regular expression for checking invalid filenames.
-     * When a filename with one of these invalid characters are detected, then it is
-     * also used to substitute the place holder of the error message.
-     */
-    var _invalidChars;
 
     /**
      * @private
@@ -76,19 +68,24 @@ define(function (require, exports, module) {
     var _illegalFilenamesRegEx = /^(\.+|com[1-9]|lpt[1-9]|nul|con|prn|aux|)$|\.+$/i;
 
     /**
+     * @private
+     * RegEx to validate if a filename contains illegal characters.
+     */
+    var _illegalCharactersRegEx = /[^0-9A-Za-z!-_.'()]/;
+
+    /**
      * Returns true if this matches valid filename specifications.
      *
      * TODO: This likely belongs in FileUtils.
      *
      * @param {string} filename to check
-     * @param {string} invalidChars List of characters that are disallowed
      * @return {boolean} true if the filename is valid
      */
-    function isValidFilename(filename, invalidChars) {
+    function isValidFilename(filename) {
         // Validate file name
         // Checks for valid Windows filenames:
         // See http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
-        return !((filename.search(new RegExp("[" + invalidChars + "]+")) !== -1) ||
+        return !((filename.search(new RegExp(_illegalCharactersRegEx)) !== -1) ||
                  filename.match(_illegalFilenamesRegEx));
     }
 
@@ -171,7 +168,7 @@ define(function (require, exports, module) {
         var d = new $.Deferred();
 
         var name = FileUtils.getBaseName(path);
-        if (!isValidFilename(name, _invalidChars)) {
+        if (!isValidFilename(name)) {
             return d.reject(ERROR_INVALID_FILENAME).promise();
         }
 
@@ -880,7 +877,7 @@ define(function (require, exports, module) {
 
         if (oldName === newName) {
             result.resolve();
-        } else if (!isValidFilename(FileUtils.getBaseNameDontIgnoreTrailingSlash(newName), _invalidChars)) {
+        } else if (!isValidFilename(FileUtils.getBaseNameDontIgnoreTrailingSlash(newName))) {
             result.reject(ERROR_INVALID_FILENAME);
         } else {
             var entry = isFolder ? FileSystem.getDirectoryForPath(oldName) : FileSystem.getFileForPath(oldName);
@@ -1324,21 +1321,12 @@ define(function (require, exports, module) {
         return welcomeProjects.indexOf(pathNoSlash) !== -1;
     }
 
-    // Init invalid characters string
-    if (brackets.platform === "mac") {
-        _invalidChars = "?*|:";
-    } else if (brackets.platform === "linux") {
-        _invalidChars = "?*|/";
-    } else {
-        _invalidChars = "/?*:<>\\|\"";  // invalid characters on Windows
-    }
 
     exports._getWelcomeProjectPath  = _getWelcomeProjectPath;
     exports._addWelcomeProjectPath  = _addWelcomeProjectPath;
     exports._isWelcomeProjectPath   = _isWelcomeProjectPath;
     exports._ensureTrailingSlash    = _ensureTrailingSlash;
     exports._shouldShowName         = _shouldShowName;
-    exports._invalidChars           = _invalidChars;
 
     exports.shouldShow              = shouldShow;
     exports.isValidFilename         = isValidFilename;

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -313,11 +313,11 @@ define(function (require, exports, module) {
         
         describe("isValidFilename", function () {
             it("returns true for filenames with nothing invalid", function () {
-                expect(ProjectModel.isValidFilename("foo.txt", "*")).toBe(true);
+                expect(ProjectModel.isValidFilename("foo.txt")).toBe(true);
             });
             
             it("returns false for filenames that match the invalid characters", function () {
-                expect(ProjectModel.isValidFilename("foo*txt", "|*")).toBe(false);
+                expect(ProjectModel.isValidFilename("foo%txt")).toBe(false);
             });
             
             it("returns false for filenames that match the internal list of disallowed names", function () {


### PR DESCRIPTION
There's an issue where creating a filename with "%" causes JS errors. There's a bunch of problematic characters so this narrows the character set that we allow for filenames.
<img width="1425" alt="Screen Shot 2020-07-09 at 2 57 13 PM" src="https://user-images.githubusercontent.com/17147070/87079746-82de2900-c1f4-11ea-8437-41aa7bd42e89.png">

- [jira](https://codedotorg.atlassian.net/browse/STAR-481)

DISCLAIMER: I have not been able to figure out how to run the tests yet. I updated what looked like the relevant tests but I'm pretty stuck on how to run them.