### PR TITLE
Update engine (node + npm) versions to match code-dot-org repo versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "dist"
     ],
     "engines": {
-        "node": "^6.11.1",
-        "npm": "^3.10.10"
+        "node": ">=8.15",
+        "npm": ">=3.10.8"
     },
     "dependencies": {
         "anymatch": "1.3.0",

--- a/src/config.json
+++ b/src/config.json
@@ -23,7 +23,7 @@
         "healthDataServerURL": "https://health.brackets.io/healthDataLog"
     },
     "name": "@code-dot-org/bramble",
-    "version": "0.1.26",
+    "version": "0.1.28",
     "homepage": "https://github.com/code-dot-org/bramble",
     "repository": {
         "type": "git",
@@ -35,8 +35,8 @@
         "dist"
     ],
     "engines": {
-        "node": "^6.11.1",
-        "npm": "^3.10.10"
+        "node": ">=8.15",
+        "npm": ">=3.10.8"
     },
     "dependencies": {
         "anymatch": "1.3.0",
@@ -95,7 +95,7 @@
         "localize-dist": "node scripts/properties2js dist",
         "unlocalize": "rimraf src/nls && git checkout -- src/nls",
         "postinstall": "grunt install",
-        "build": "grunt build-browser-dev",
+        "build": "grunt build-browser",
         "watch:api": "grunt watch:bramble",
         "preproduction": "grunt build-browser-compressed && npm run unlocalize",
         "production": "npm start -- --gzip",


### PR DESCRIPTION
Upgrading the node and NPM versions to match those in the code-dot-org repo [here](https://github.com/code-dot-org/code-dot-org/blob/0eba16da126138df74e39f6c2b7f395ce13dfafb/apps/package.json#L6-L9).

This came up after I published v0.1.28 of Bramble to NPM. When I tried to upgrade the Bramble package in code-dot-org, I got this error:
![Screen Shot 2020-09-02 at 1 33 45 PM](https://user-images.githubusercontent.com/9812299/92034021-7fad7800-ed21-11ea-97cd-9c39c8911f8d.png)

After updating these versions, I made sure I was able to build, start the server, and run tests successfully.