### PR TITLE
Bramble WebLab changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ should host Bramble's iframe, see `src/hosted.js`.
 
 # Publishing a new version of Bramble
 
-_Note: These instructions are specific to Code.org. We publish and host new versions of Bramble using S3, which means you need permissions to access AWS as a Code.org engineer. We used to also publish Bramble to NPM ([@code-dot-org/bramble](https://www.npmjs.com/package/@code-dot-org/bramble)), but we only use S3 now -- do not publish new versions to NPM._
+_Note: These instructions are specific to Code.org. We publish and host new versions of Bramble using S3, which means you need permissions to access AWS as a Code.org engineer. We used to also publish Bramble to NPM ([@code-dot-org/bramble](https://www.npmjs.com/package/@code-dot-org/bramble)), but we only use S3 now -- do not publish new versions to NPM. If we were to begin publishing Bramble to NPM again, we would need to first publish a new version to NPM as it is already out of date._
 
 1. Generate a new build by running `npm run build` from the root directory. This updates the `dist/` directory, which is our build output.
 2. Log in to S3 using your Code.org credentials.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,17 @@
-# Bramble is based on Brackets
+# Code.org's Bramble is based on Brackets
 
-Brackets is a modern open-source code editor for HTML, CSS
-and JavaScript that is  *built* in HTML, CSS and JavaScript.
+Code.org maintains a fork of [mozilla/brackets](https://github.com/mozilla/brackets), which is a fork of [adobe/brackets](https://github.com/adobe/brackets). Currently, we make changes directly to our fork. Please add a `CDO-Bramble` comment when you make a change to this repository -- if we encounter merge conflicts when pulling from upstream, this helps us understand which changes are ours and why they were made. Example:
 
-Brackets is at 1.0 and we're not stopping there. We have many feature ideas on our
-[trello board](http://bit.ly/BracketsTrelloBoard) that we're anxious to add and other
-innovative web development workflows that we're planning to build into Brackets.
-So take Brackets out for a spin and let us know how we can make it your favorite editor.
+```javascript
+// CDO-Bramble: We do not want to use this feature. Return early.
+return;
+```
 
-You can see some
-[screenshots of Brackets](https://github.com/adobe/brackets/wiki/Brackets-Screenshots)
-on the wiki, [intro videos](http://www.youtube.com/user/CodeBrackets) on YouTube, and news on the [Brackets blog](http://blog.brackets.io/).
-
-The text editor inside Brackets is based on
-[CodeMirror](http://github.com/codemirror/CodeMirror)&mdash;thanks to Marijn for
-taking our pull requests, implementing feature requests and fixing bugs! See
-[Notes on CodeMirror](https://github.com/adobe/brackets/wiki/Notes-on-CodeMirror)
-for info on how we're using CodeMirror.
+Ideally, this comment will also tell us _why_ functionality is being changed so we understand in the future if that change is still wanted/necessary.
 
 # How to setup Bramble (Brackets) in your local machine
 
-Step 1: Make sure you clone our fork of [Bramble](https://github.com/mozilla/brackets) recursively.
+Step 1: Make sure you clone our fork of [Bramble](https://github.com/code-dot-org/bramble) recursively.
 
 ```
 $ git clone https://github.com/code-dot-org/bramble.git --recursive
@@ -69,6 +60,17 @@ should host Bramble's iframe, see `src/hosted.js`.
 **NOTE 2:** Using `npm run build` will overwrite contents in the `src/nls` folder. These changes are necessary if you access Bramble using [http://localhost:8000/src](http://localhost:8000/src). After using Bramble, you can undo the changes by running `npm run unlocalize`.
 
 **NOTE 3:** To use Bramble in a production setting locally, you can run `npm run production` and access Bramble at [http://localhost:8000/dist](http://localhost:8000/dist)
+
+# Publishing a new version of Bramble
+
+_Note: These instructions are specific to Code.org. We publish and host new versions of Bramble using S3, which means you need permissions to access AWS as a Code.org engineer. We used to also publish Bramble to NPM ([@code-dot-org/bramble](https://www.npmjs.com/package/@code-dot-org/bramble)), but we only use S3 now -- do not publish new versions to NPM._
+
+1. Generate a new build by running `npm run build` from the root directory. This updates the `dist/` directory, which is our build output.
+2. Log in to S3 using your Code.org credentials.
+3. Go to the `downloads.computinginthecore.org` bucket.
+4. Create a new folder for our new build called `bramble_{version}`.
+5. Open that new folder and upload the contents `dist/`.
+6. You now have a new version of Bramble that is publically accessible!
 
 # Extension Loading
 

--- a/src/extensions/default/BrambleUrlCodeHints/camera/index.js
+++ b/src/extensions/default/BrambleUrlCodeHints/camera/index.js
@@ -27,9 +27,12 @@ define(function (require, exports, module) {
         this.photo = new Photo(this);
         this.interface = new Interface(this);
     }
+
+    // CDO-Bramble: Disable camera support. It is currently only used to take "selfies"
+    // as a source for <img> elements, which we do not support.
     // Expose a feature testing property for browsers that
     // do not support this functionality of HTML5
-    Camera.isSupported = !!getUserMedia;
+    Camera.isSupported = false;
 
     // Initiate the camera by requesting access to the user's webcam
     Camera.prototype.start = function() {

--- a/src/extensions/default/BrambleUrlCodeHints/camera/index.js
+++ b/src/extensions/default/BrambleUrlCodeHints/camera/index.js
@@ -28,7 +28,7 @@ define(function (require, exports, module) {
         this.interface = new Interface(this);
     }
 
-    // CDO-Bramble: Disable camera support. It is currently only used to take "selfies"
+    // CDO-Bramble: Disable camera support. As of Jan. 2021, this property is only used to take "selfies"
     // as a source for <img> elements, which we do not support.
     // Expose a feature testing property for browsers that
     // do not support this functionality of HTML5

--- a/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
+++ b/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
@@ -125,6 +125,9 @@ define(function (require, exports, module) {
     }
 
     AppInit.htmlReady(function () {
+        // CDO-Bramble: We do not want to display the JavaScript console. Return early.
+        return;
+
         ExtensionUtils.loadStyleSheet(module, "../stylesheets/consoleTheme.less");
 
         // Localization & Creation of HTMl Elements


### PR DESCRIPTION
Updates to our version of Bramble based on [bug bash feedback](https://docs.google.com/document/d/139A3Ck_uk8gWLOUJJBeqU6cA9cpJmvVwHTPjROvhUNc/edit#):
- [[doc bookmark](https://docs.google.com/document/d/139A3Ck_uk8gWLOUJJBeqU6cA9cpJmvVwHTPjROvhUNc/edit#bookmark=kix.jnl1jbuo7y3v)][[commit](https://github.com/code-dot-org/bramble/pull/11/commits/21a746a5e3daeaa5df87127980c277960be205ca)] Remove the JavaScript console. JavaScript isn't part of our WebLab curriculum, so don't display/promote the console. Students have always been able to create/use JavaScript files in WebLab if they want to, and that's okay.
- [[doc bookmark](https://docs.google.com/document/d/139A3Ck_uk8gWLOUJJBeqU6cA9cpJmvVwHTPjROvhUNc/edit#bookmark=id.du55dp8dbaxw)][[commit](https://github.com/code-dot-org/bramble/pull/11/commits/77283bcacc71318c252e263f7b87f4d9986cb685)] Disable camera support. The camera is only used to take "selfies" to use as an image element source, which we do not support. This has been broken on production for an unknown amount of time so it's not a new feature from this upgrade, but something I wanted to disable while I'm here.

I've also updated the README to include steps for how to publish a new version of Bramble in [this commit](https://github.com/code-dot-org/bramble/pull/11/commits/bd30684101eb2ffb41b794108acfdabf8a3e0152).

These changes have already been deployed to a new version in S3 ([version 0.1.27](https://s3.console.aws.amazon.com/s3/buckets/downloads.computinginthecore.org?region=us-east-1&prefix=bramble_0.1.27/&showversions=false)) because I wanted to make sure I understood the required build/publish steps for Bramble as I've only done it once before and needed to update the README steps.