### PR TITLE
Remove custom code that disallowed renaming a file to "index.html"

### DIFF
--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -188,8 +188,9 @@ define(function (require, exports, module) {
             CommandManager.execute("bramble.showUploadFiles").always(callback);
             break;
         case "BRAMBLE_FILE_REFRESH":
-            // CDO-Bramble: Allows us to manually refresh the file tree. This is
-            // necessary because we manage our own "Manage Assets" modal for uploading images.
+            // CDO-Bramble: This command is custom to our fork. It allows us to manually
+            // refresh the file tree. This is necessary because we manage our own
+            // "Manage Assets" modal for uploading images.
             skipCallback = true;
             CommandManager
                 .execute("bramble.fileRefresh")

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -188,6 +188,8 @@ define(function (require, exports, module) {
             CommandManager.execute("bramble.showUploadFiles").always(callback);
             break;
         case "BRAMBLE_FILE_REFRESH":
+            // CDO-Bramble: Allows us to manually refresh the file tree. This is
+            // necessary because we manage our own "Manage Assets" modal for uploading images.
             skipCallback = true;
             CommandManager
                 .execute("bramble.fileRefresh")

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -962,12 +962,6 @@ define(function (require, exports, module) {
 
         if (isFolder) {
             newPath += "/";
-        } else {
-            var blockedPath = this.projectRoot.fullPath + 'index.html';
-            if (newPath.toLowerCase() === blockedPath.toLowerCase()) {
-                this.cancelRename();
-                return;
-            }
         }
 
         delete this._selections.rename;


### PR DESCRIPTION
[STAR-981](https://codedotorg.atlassian.net/browse/STAR-981)

Removes code that was custom to our fork (added in [this commit](https://github.com/code-dot-org/bramble/commit/4c4b9297ac9767e84cfe9942280dbbf284adfa5d)) that disallowed renaming an HTML file to `index.html`. Sometimes students get into a sticky situation where they don't have an index.html file in their project, and we disallowed renaming to index.html, so the student had to have a Code.org engineer fix their project for them.

When a user is missing an index.html file in their Weblab project, they see the same modal as before:
![Screen Shot 2021-01-20 at 4 33 25 PM](https://user-images.githubusercontent.com/9812299/105258239-28783a80-5b3e-11eb-8238-d04ba512235a.png)

But now they are able to create an index.html file after they close the modal. (More specifically, they create a new.html file -- which is the default name for our HTML files -- then rename that file to index.html.)

Also adds a comment that I should've added in #8 to call out that the "BRAMBLE_FILE_REFRESH" command is custom to our fork.

Once this and [STAR-481](https://codedotorg.atlassian.net/browse/STAR-481) (not yet implemented) have been merged, I'll build a new version of Bramble, deploy it to S3, and integrate that new version into Code Studio.