### PR TITLE
Handle null panel since we have disabled js console panel

### DIFF
--- a/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
+++ b/src/extensions/default/bramble/lib/ConsoleInterfaceManager.js
@@ -95,6 +95,9 @@ define(function (require, exports, module) {
     }
 
     function add(type, args) {
+        // CDO-Bramble: We do not display this panel. Return early.
+        if (!panel) return;
+
         // Display the console when user code triggers console.* functions,
         // but only if the console was not already closed by the user.
         if(!panel.isVisible() && !wasClosedByUser) {
@@ -116,6 +119,9 @@ define(function (require, exports, module) {
     }
 
     function togglePanel() {
+      // CDO-Bramble: We do not display this panel. Return early.
+        if (!panel) return;
+
         if (panel.isVisible()) {
             hidePanel();
         } else {


### PR DESCRIPTION
Fixes an oversight I made in [this commit](https://github.com/code-dot-org/bramble/pull/11/commits/21a746a5e3daeaa5df87127980c277960be205ca) where I disabled the JavaScript console in Bramble.

Since we return early in the commit above, `panel` was always null, which would throw some errors in the browser console when running Bramble locally. I didn't notice this before because those errors aren't thrown in Code Studio, which was where I was testing this change. This didn't have any user impact, but we should prevent those errors.