### PR TITLE
Add commands to set readOnly mode after instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,12 +338,16 @@ to be notified when the action completes:
 * `hideTutorial([callback])` - stops showing tutorial (i.e., tutorial.html) and uses editor contents in preview
 * `showUploadFilesDialog([callback])` - shows the Upload Files dialog, allowing users to drag-and-drop, upload a file, or take a selfie.
 * `addNewFile([options, callback])` - adds a new text file, using the provided options, which can include: `filename` a `String` with the complete filename to use; `contents` a `String` with the new text file's data; `ext` a `String` with the new file's extension; `basenamePrefix` a `String` with the basename to use when generating a new filename.  NOTE: if you provide `filename`, `basenamePrefix` and `ext` are ignored.
-* `fileRefresh([callback])` - refreshes files in the project tree (custom for CDO-Bramble).
 * `addNewFolder([callback])` - adds a new folder.
 * `export([callback])` - creates an archive `.zip` file of the entire project's filesystem, and downloads it to the browser.
 * `addCodeSnippet(snippet, [callback])` - adds a new code `snippet` to the editor (if it is in focus) at the current cursor position. One required parameter (`snippet`) needs to be passed in which needs to be a `String`.
 * `openSVGasXML([callback])` - treats `.svg` files as XML and shows them in the text editor.
 * `openSVGasImage([callback])` - treats `.svg` files as Images and shows them in image viewer.
+
+The following instance methods are custom to Code.org's fork of Bramble:
+* `fileRefresh([callback])` - refreshes files in the project tree.
+* `enableReadonly()` - enables readOnly mode for the current editor.
+* `disableReadonly()` - disables readOnly mode for the current editor.
 
 ## Bramble Instance Events
 

--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ to be notified when the action completes:
 
 The following instance methods are custom to Code.org's fork of Bramble:
 * `fileRefresh([callback])` - refreshes files in the project tree.
-* `enableReadonly()` - enables readOnly mode for the current editor.
-* `disableReadonly()` - disables readOnly mode for the current editor.
+* `enableReadOnly()` - enables readOnly mode for the current editor.
+* `disableReadOnly()` - disables readOnly mode for the current editor.
 
 ## Bramble Instance Events
 

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -1179,14 +1179,14 @@ define([
     /**
      * CDO-Bramble: Enable readOnly mode in the current editor.
      */
-    BrambleProxy.prototype.enableReadonly = function() {
+    BrambleProxy.prototype.enableReadOnly = function() {
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ENABLE_READONLY"});
     }
 
     /**
      * CDO-Bramble: Disable readOnly mode in the current editor.
      */
-    BrambleProxy.prototype.disableReadonly = function() {
+    BrambleProxy.prototype.disableReadOnly = function() {
         this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_DISABLE_READONLY"});
     }
 

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -1176,5 +1176,19 @@ define([
         }, callback);
     };
 
+    /**
+     * CDO-Bramble: Enable readOnly mode in the current editor.
+     */
+    BrambleProxy.prototype.enableReadonly = function() {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_ENABLE_READONLY"});
+    }
+
+    /**
+     * CDO-Bramble: Disable readOnly mode in the current editor.
+     */
+    BrambleProxy.prototype.disableReadonly = function() {
+        this._executeRemoteCommand({commandCategory: "bramble", command: "BRAMBLE_DISABLE_READONLY"});
+    }
+
     return Bramble;
 });

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2402,7 +2402,7 @@ define(function (require, exports, module) {
     };
 
     // CDO-Bramble: Set readOnly mode.
-    Editor.prototype.setReadonly = function(value) {
+    Editor.prototype.setReadOnly = function(value) {
         this._codeMirror.setOption("readOnly", value);
     };
 

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2401,6 +2401,11 @@ define(function (require, exports, module) {
         }
     };
 
+    // CDO-Bramble: Set readOnly mode.
+    Editor.prototype.setReadonly = function(value) {
+        this._codeMirror.setOption("readOnly", value);
+    };
+
 
     // Global settings that affect Editor instances that share the same preference locations
 

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -691,10 +691,10 @@ define(function (require, exports, module) {
     }
 
     // CDO-Bramble: Set readOnly mode for the current editor.
-    function setEditorReadonly(value) {
+    function setEditorReadOnly(value) {
         var currentEditor = getCurrentFullEditor();
         if (currentEditor) {
-            currentEditor.setReadonly(value);
+            currentEditor.setReadOnly(value);
         }
     }
 
@@ -895,7 +895,7 @@ define(function (require, exports, module) {
     exports.closeInlineWidget             = closeInlineWidget;
     exports.openDocument                  = openDocument;
     exports.canOpenPath                   = canOpenPath;
-    exports.setEditorReadonly             = setEditorReadonly;
+    exports.setEditorReadOnly             = setEditorReadOnly;
 
     // Convenience Methods
     exports.getActiveEditor               = getActiveEditor;

--- a/src/editor/EditorManager.js
+++ b/src/editor/EditorManager.js
@@ -690,6 +690,14 @@ define(function (require, exports, module) {
         return !LanguageManager.getLanguageForPath(fullPath).isBinary();
     }
 
+    // CDO-Bramble: Set readOnly mode for the current editor.
+    function setEditorReadonly(value) {
+        var currentEditor = getCurrentFullEditor();
+        if (currentEditor) {
+            currentEditor.setReadonly(value);
+        }
+    }
+
     /**
      * Opens the specified document in the given pane
      * @param {!Document} doc - the document to open
@@ -887,6 +895,7 @@ define(function (require, exports, module) {
     exports.closeInlineWidget             = closeInlineWidget;
     exports.openDocument                  = openDocument;
     exports.canOpenPath                   = canOpenPath;
+    exports.setEditorReadonly             = setEditorReadonly;
 
     // Convenience Methods
     exports.getActiveEditor               = getActiveEditor;

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -232,10 +232,10 @@ define(function (require, exports, module) {
                 .always(callback);
             break;
         case "BRAMBLE_ENABLE_READONLY":
-            EditorManager.setEditorReadonly(true);
+            EditorManager.setEditorReadOnly(true);
             break;
         case "BRAMBLE_DISABLE_READONLY":
-            EditorManager.setEditorReadonly(false);
+            EditorManager.setEditorReadOnly(false);
             break;
         default:
             console.log('[Bramble] unknown command:', command);

--- a/src/extensions/default/bramble/lib/RemoteCommandHandler.js
+++ b/src/extensions/default/bramble/lib/RemoteCommandHandler.js
@@ -187,15 +187,6 @@ define(function (require, exports, module) {
             skipCallback = true;
             CommandManager.execute("bramble.showUploadFiles").always(callback);
             break;
-        case "BRAMBLE_FILE_REFRESH":
-            // CDO-Bramble: This command is custom to our fork. It allows us to manually
-            // refresh the file tree. This is necessary because we manage our own
-            // "Manage Assets" modal for uploading images.
-            skipCallback = true;
-            CommandManager
-                .execute("bramble.fileRefresh")
-                .always(callback);
-            break;
         case "BRAMBLE_ADD_NEW_FILE":
             skipCallback = true;
             // Make sure we have enough room to add new files.
@@ -232,6 +223,19 @@ define(function (require, exports, module) {
             break;
         case "BRAMBLE_PROJECT_SIZE_CHANGE":
             UI.setProjectSizeInfo(args[0]);
+            break;
+        // CDO-Bramble: The remaining commands are custom to our fork.
+        case "BRAMBLE_FILE_REFRESH":
+            skipCallback = true;
+            CommandManager
+                .execute("bramble.fileRefresh")
+                .always(callback);
+            break;
+        case "BRAMBLE_ENABLE_READONLY":
+            EditorManager.setEditorReadonly(true);
+            break;
+        case "BRAMBLE_DISABLE_READONLY":
+            EditorManager.setEditorReadonly(false);
             break;
         default:
             console.log('[Bramble] unknown command:', command);


### PR DESCRIPTION
Prior to this change, we could set `readOnly` when instantiating Bramble ([Code Studio example](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/weblab/brambleHost.js#L610)), but Bramble did not expose instance methods for updating readOnly after the editor was created.

This change was made to accommodate disallowing certain HTML tags in WebLab ([PR](https://github.com/code-dot-org/code-dot-org/pull/39207)). When we find a disallowed tag in a user's HTML, we remove it and overwrite the file contents. We want to set the editor to readOnly mode while overwriting file contents.