### PR TITLE
Update version and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ _Note: These instructions are specific to Code.org. We publish and host new vers
 4. Create a new folder for our new build called `bramble_{version}`.
 5. Open that new folder and upload the contents `dist/`.
 6. You now have a new version of Bramble that is publically accessible!
+7. Update the package.json file in this repository to match the new version. This is just for organization and clarity.
 
 # Extension Loading
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@code-dot-org/bramble",
-    "version": "0.1.29",
+    "version": "0.1.28",
     "homepage": "https://github.com/code-dot-org/bramble",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fixes the version in package.json, which became out-of-sync with our S3 version when I was attempting (and failing) to upgrade our version of Bramble via NPM. 

We don't publish to NPM anymore, so the version in package.json doesn't do anything, but we should keep it up-to-date for clarity. I added this as a step for publishing in our README as well.

After #14 has been merged, this PR should be merged and a new version of Bramble will be published.