### PR TITLE
Fix filer submodule commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,7 @@
 [submodule "src/thirdparty/filer"]
 	path = src/thirdparty/filer
 	url = https://github.com/code-dot-org/filer.git
+	branch = cdo-develop
 [submodule "src/thirdparty/marked"]
 	path = src/thirdparty/marked
 	url = https://github.com/chjj/marked.git

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@code-dot-org/bramble",
-    "version": "0.1.28",
+    "version": "0.1.29",
     "homepage": "https://github.com/code-dot-org/bramble",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Fixes the commit for our filer submodule to point to the [latest commit on the `cdo-develop` branch](https://github.com/code-dot-org/filer/commit/dc92020b256775b96dd1e4fd11a135762076d8a3) as it includes an important fix for the "red dots" issue on Safari ([STAR-1468](https://codedotorg.atlassian.net/browse/STAR-1468)).

I made the exact same mistake as #4, which means our current filer submodule is pointing to the latest commit on `develop` instead of `cdo-develop`. Explicitly setting the branch to `cdo-develop` in our submodules configuration should help prevent this from happening again.

I fixed this issue by doing the following from the root directory:

```bash
cd src/thirdparty/filer/ # go to submodule directory
git checkout cdo-develop
git pull

cd ../../../ # go back to root
git submodule init
git submodule update
```

I updated the version of Bramble as well and will upload a new version to S3 after this is merged.