### PR TITLE
Track valid filename characters instead of invalid characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@code-dot-org/bramble",
-    "version": "0.1.29",
+    "version": "0.1.30",
     "homepage": "https://github.com/code-dot-org/bramble",
     "repository": {
         "type": "git",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -67,7 +67,7 @@ define({
     "ERROR_DELETING_FILE"               : "An error occurred when trying to delete the {2} <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Invalid {0}",
     "INVALID_FILENAME_MESSAGE"          : "{0} cannot use any system reserved words, end with dots (.) or use any of the following characters: <code class='emphasized'>{1}</code>",
-    "CDO_INVALID_FILENAME_MESSAGE"      : "{0} cannot use any system reserved words, end with dots (.) or use any disallowed characters. Allowed characters: <code class='emphasized'>{1}</code>",
+    "CDO_INVALID_FILENAME_MESSAGE"      : "{0} must only use allowed characters, cannot use any system reserved words, and cannot end with dots (.). Allowed characters: <code class='emphasized'>{1}</code>",
     "ENTRY_WITH_SAME_NAME_EXISTS"       : "A file or directory with the name <span class='dialog-filename'>{0}</span> already exists.",
     "ERROR_CREATING_FILE_TITLE"         : "Error Creating {0}",
     "ERROR_CREATING_FILE"               : "An error occurred when trying to create the {0} <span class='dialog-filename'>{1}</span>. {2}",

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -67,6 +67,7 @@ define({
     "ERROR_DELETING_FILE"               : "An error occurred when trying to delete the {2} <span class='dialog-filename'>{0}</span>. {1}",
     "INVALID_FILENAME_TITLE"            : "Invalid {0}",
     "INVALID_FILENAME_MESSAGE"          : "{0} cannot use any system reserved words, end with dots (.) or use any of the following characters: <code class='emphasized'>{1}</code>",
+    "CDO_INVALID_FILENAME_MESSAGE"      : "{0} cannot use any system reserved words, end with dots (.) or use any disallowed characters. Allowed characters: <code class='emphasized'>{1}</code>",
     "ENTRY_WITH_SAME_NAME_EXISTS"       : "A file or directory with the name <span class='dialog-filename'>{0}</span> already exists.",
     "ERROR_CREATING_FILE_TITLE"         : "Error Creating {0}",
     "ERROR_CREATING_FILE"               : "An error occurred when trying to create the {0} <span class='dialog-filename'>{1}</span>. {2}",

--- a/src/project/ProjectManager.js
+++ b/src/project/ProjectManager.js
@@ -179,7 +179,7 @@ define(function (require, exports, module) {
             if (error === FileSystemError.ALREADY_EXISTS) {
                 _showErrorDialog(ERR_TYPE_CREATE_EXISTS, isFolder, null, name);
             } else if (error === ProjectModel.ERROR_INVALID_FILENAME) {
-                _showErrorDialog(ERR_TYPE_INVALID_FILENAME, isFolder, ProjectModel._invalidChars);
+                _showErrorDialog(ERR_TYPE_INVALID_FILENAME, isFolder, ProjectModel._validChars);
             } else {
                 var errString = error === FileSystemError.NOT_WRITABLE ?
                         Strings.NO_MODIFICATION_ALLOWED_ERR :
@@ -604,7 +604,8 @@ define(function (require, exports, module) {
             break;
         case ERR_TYPE_INVALID_FILENAME:
             title = StringUtils.format(Strings[isFolder ? "INVALID_DIRNAME_TITLE" : "INVALID_FILENAME_TITLE"], isFolder ? Strings.DIRECTORY_NAME : Strings.FILENAME);
-            message = StringUtils.format(Strings[isFolder ? "INVALID_DIRNAME_MESSAGE" : "INVALID_FILENAME_MESSAGE"], isFolder ? Strings.DIRECTORY_NAMES_LEDE : Strings.FILENAMES_LEDE, error);
+            // CDO-Bramble: Use custom, English-only CDO_INVALID_FILENAME_MESSAGE string for invalid filenames.
+            message = StringUtils.format(Strings[isFolder ? "INVALID_DIRNAME_MESSAGE" : "CDO_INVALID_FILENAME_MESSAGE"], isFolder ? Strings.DIRECTORY_NAMES_LEDE : Strings.FILENAMES_LEDE, error);
             break;
         }
 
@@ -1308,7 +1309,7 @@ define(function (require, exports, module) {
 
                     switch (errorInfo.type) {
                     case ProjectModel.ERROR_INVALID_FILENAME:
-                        _showErrorDialog(ERR_TYPE_INVALID_FILENAME, errorInfo.isFolder, ProjectModel._invalidChars);
+                        _showErrorDialog(ERR_TYPE_INVALID_FILENAME, errorInfo.isFolder, ProjectModel._validChars);
                         break;
                     case FileSystemError.ALREADY_EXISTS:
                         _showErrorDialog(ERR_TYPE_RENAME, errorInfo.isFolder, Strings.FILE_EXISTS_ERR, filename);

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -89,10 +89,10 @@ define(function (require, exports, module) {
      * CDO-Bramble: We have more strict requirements for allowed filename characters
      * than Bramble. Use an allowlist instead of a list of invalid characters.
      */
-    var _validCharsRegex = /[^0-9A-Za-z!\-_.*'()]/;
+    var _invalidCharsRegex = /[^0-9A-Za-z!\-_.*'()]/;
     var _validChars = "0-9 a-z A-Z ! - _ . * ' ( )"; // CDO-Bramble: Only for use in error messages.
     function isValidCdoFilename(filename) {
-        return !(_validCharsRegex.test(filename) || _illegalFilenamesRegEx.test(filename));
+        return !(_invalidCharsRegex.test(filename) || _illegalFilenamesRegEx.test(filename));
     }
 
     /**

--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -86,6 +86,16 @@ define(function (require, exports, module) {
     var _illegalFilenamesRegEx = /^(\.+|com[1-9]|lpt[1-9]|nul|con|prn|aux|)$|\.+$/i;
 
     /**
+     * CDO-Bramble: We have more strict requirements for allowed filename characters
+     * than Bramble. Use an allowlist instead of a list of invalid characters.
+     */
+    var _validCharsRegex = /[^0-9A-Za-z!\-_.*'()]/;
+    var _validChars = "0-9 a-z A-Z ! - _ . * ' ( )"; // CDO-Bramble: Only for use in error messages.
+    function isValidCdoFilename(filename) {
+        return !(_validCharsRegex.test(filename) || _illegalFilenamesRegEx.test(filename));
+    }
+
+    /**
      * Returns true if this matches valid filename specifications.
      *
      * TODO: This likely belongs in FileUtils.
@@ -183,7 +193,7 @@ define(function (require, exports, module) {
         var d = new $.Deferred();
 
         var name = FileUtils.getBaseName(path);
-        if (!isValidFilename(name, _invalidChars)) {
+        if (!isValidCdoFilename(name)) {
             return d.reject(ERROR_INVALID_FILENAME).promise();
         }
 
@@ -906,7 +916,7 @@ define(function (require, exports, module) {
 
         if (oldPath === newPath) {
             result.resolve();
-        } else if (!isValidFilename(FileUtils.getBaseNameDontIgnoreTrailingSlash(newName), _invalidChars)) {
+        } else if (!isValidCdoFilename(FileUtils.getBaseNameDontIgnoreTrailingSlash(newName))) {
             result.reject(ERROR_INVALID_FILENAME);
         } else {
             var entry = isFolder ? FileSystem.getDirectoryForPath(oldPath) : FileSystem.getFileForPath(oldPath);
@@ -1360,6 +1370,8 @@ define(function (require, exports, module) {
     exports._ensureTrailingSlash    = _ensureTrailingSlash;
     exports._shouldShowName         = _shouldShowName;
     exports._invalidChars           = _invalidChars;
+    // CDO-Bramble: Export _validChars for use in error messages managed by ProjectManager.
+    exports._validChars = _validChars;
 
     exports.shouldShow              = shouldShow;
     exports.defaultIgnoreGlobs      = defaultIgnoreGlobs;


### PR DESCRIPTION
[STAR-481](https://codedotorg.atlassian.net/browse/STAR-481)

It's much easier to manage an allowlist for valid filename characters than to continually add to a disallowlist, so this PR introduces that change.

**Before**
<img width="635" alt="Screen Shot 2021-03-12 at 12 46 10 PM" src="https://user-images.githubusercontent.com/9812299/110996547-f2cb2300-8330-11eb-8e85-1a14e92348ec.png">

**After**
<img width="640" alt="Screen Shot 2021-03-12 at 12 44 42 PM" src="https://user-images.githubusercontent.com/9812299/110996564-f6f74080-8330-11eb-9458-0d2d10bb623a.png">

This also updates the bramble version to 0.1.30. After this PR, #18, and #19 are merged, I will upload a new build to S3 and integrate the new version into Code Studio.