### PR TITLE
Disable drag-and-drop file upload

### DIFF
--- a/src/brackets.js
+++ b/src/brackets.js
@@ -251,9 +251,15 @@ define(function (require, exports, module) {
         // Update title
         $("title").text(brackets.config.app_title);
 
+        /**
+         * CDO-Bramble: We do not support dragging/dropping files to upload them. However,
+         * we still need to attach no-op handlers that will prevent dropping a file onto the window
+         * from replacing the Brackets UI with that file.
+         */
         // Respond to dragging & dropping files/folders onto the window by opening them. If we don't respond
         // to these events, the file would load in place of the Brackets UI
-        DragAndDrop.attachHandlers();
+        // DragAndDrop.attachHandlers();
+        DragAndDrop.attachNoopHandlers();
 
         // TODO: (issue 269) to support IE, need to listen to document instead (and even then it may not work when focus is in an input field?)
         $(window).focus(function () {

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -318,6 +318,8 @@ define(function (require, exports, module) {
         options.elem.addEventListener("drop", codeMirrorDropHandler, true);
     }
 
+    // CDO-Bramble: No-op dragover and drop events to prevent the given element (or window by default)
+    // from being replaced by the dropped file.
     function attachNoopHandlers(options) {
         options = options || {};
         options.elem = options.elem || window.document.body;

--- a/src/utils/DragAndDrop.js
+++ b/src/utils/DragAndDrop.js
@@ -318,6 +318,18 @@ define(function (require, exports, module) {
         options.elem.addEventListener("drop", codeMirrorDropHandler, true);
     }
 
+    function attachNoopHandlers(options) {
+        options = options || {};
+        options.elem = options.elem || window.document.body;
+
+        options.elem.addEventListener("dragover", function(e) {
+            e.preventDefault();
+        });
+        options.elem.addEventListener("drop", function(e) {
+            e.preventDefault();
+        });
+    }
+
     /**
      * Given a `source` of files (DataTransfer or FileList objects), get the associated files
      * and process them, such that they end
@@ -362,6 +374,7 @@ define(function (require, exports, module) {
     // Export public API
     exports.processFiles        = processFiles;
     exports.attachHandlers      = attachHandlers;
+    exports.attachNoopHandlers  = attachNoopHandlers;
     exports.isValidDrop         = isValidDrop;
     exports.openDroppedFiles    = openDroppedFiles;
     exports.setDropPathHint     = setDropPathHint;


### PR DESCRIPTION
[STAR-1474](https://codedotorg.atlassian.net/browse/STAR-1474)

Previously, a user could upload a file by dropping it onto the window. We are disabling this for a few reasons:
1. Consistency -- the rest of our tools don't generally support drag-and-drop uploads.
2. Bramble doesn't manage image files (our asset manager dialog does), so dropping an image to upload it would result in a broken image until the page was reloaded (a minor issue, but confusing).
3. Bramble doesn't do any validation on drag-and-drop-uploaded files, so invalid filenames weren't caught in this workflow.

This PR is related to #17, so I am going to include this PR when I deploy version 0.1.30 of Bramble.