### PR TITLE
Remove 'allow' attribute from Bramble iframes

### DIFF
--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -477,8 +477,10 @@ define([
                 div = document.body;
             }
 
+            // CDO-Bramble: Upstream includes an 'allow' attribute that enables geolocation, microphone, and camera access.
+            // We do not want that.
             div.innerHTML = "<iframe id='" + _id +
-                            "' frameborder='0' width='100%' height='100%' allow='geolocation *; microphone *; camera *'></iframe>";
+                            "' frameborder='0' width='100%' height='100%'></iframe>";
 
             _iframe = document.getElementById(_id);
             if (options.hideUntilReady) {

--- a/src/extensions/default/bramble/lib/iframe-browser.js
+++ b/src/extensions/default/bramble/lib/iframe-browser.js
@@ -45,8 +45,11 @@ define(function (require, exports, module) {
             id: "bramble-iframe-browser",
             frameborder: 0
         };
+
+        // CDO-Bramble: Upstream includes an 'allow' attribute that enables geolocation, microphone, and camera access.
+        // We do not want that.
         //Append iFrame to _panel
-        $("<iframe>", iframeConfig).addClass("iframeWidthHeight").prop("allow", "geolocation *; microphone *; camera *").appendTo(_panel);
+        $("<iframe>", iframeConfig).addClass("iframeWidthHeight").appendTo(_panel);
     }
 
     /*


### PR DESCRIPTION
[STAR-1489](https://codedotorg.atlassian.net/browse/STAR-1489)

Upstream added an 'allow' attribute to the 2 iframes that make up Bramble in this pull request: https://github.com/mozilla/brackets/pull/924

That attributes allows geolocation, microphone, and camera access; we don't want that functionality, so this removes it and adds explanatory comments.

I am going to include this PR when I deploy version 0.1.30 of Bramble, along with #17 and #18.