### PR TITLE
Add csp to html pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "less-plugin-autoprefix": "^1.5.1",
         "load-grunt-tasks": "3.5.0",
         "lodash": "4.15.0",
-        "phantomjs": "1.9.18",
+        "phantomjs-prebuilt": "2.1.16",
         "pica": "^3.0.4",
         "q": "1.4.1",
         "semver": "^4.1.0",

--- a/src/bramble/client/main.js
+++ b/src/bramble/client/main.js
@@ -423,7 +423,7 @@ define([
                 }
                 // Anything else is some kind of event we need to re-trigger
                 // and alter internal state.
-                else {
+                else if (data.type) {
                     // Strip the "bramble:*" namespace off event name
                     var eventName = data.type.replace(/^bramble:/, '');
                     delete data.type;

--- a/src/config.json
+++ b/src/config.json
@@ -68,7 +68,7 @@
         "less-plugin-autoprefix": "^1.5.1",
         "load-grunt-tasks": "3.5.0",
         "lodash": "4.15.0",
-        "phantomjs": "1.9.18",
+        "phantomjs-prebuilt": "2.1.16",
         "pica": "^3.0.4",
         "q": "1.4.1",
         "semver": "^4.1.0",

--- a/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/node_modules/.package-lock.json
+++ b/src/extensions/default/JavaScriptQuickEdit/unittest-files/jquery-ui/node_modules/.package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "jquery-ui",
+  "version": "1.9.0pre",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/extensions/default/bramble/lib/iframe-browser.js
+++ b/src/extensions/default/bramble/lib/iframe-browser.js
@@ -43,8 +43,7 @@ define(function (require, exports, module) {
         // Create the iFrame for the blob to live in later
         var iframeConfig = {
             id: "bramble-iframe-browser",
-            frameborder: 0,
-            sandbox: 'allow-same-origin'
+            frameborder: 0
         };
 
         // CDO-Bramble: Upstream includes an 'allow' attribute that enables geolocation, microphone, and camera access.

--- a/src/extensions/default/bramble/lib/iframe-browser.js
+++ b/src/extensions/default/bramble/lib/iframe-browser.js
@@ -43,7 +43,8 @@ define(function (require, exports, module) {
         // Create the iFrame for the blob to live in later
         var iframeConfig = {
             id: "bramble-iframe-browser",
-            frameborder: 0
+            frameborder: 0,
+            sandbox: 'allow-same-origin'
         };
 
         // CDO-Bramble: Upstream includes an 'allow' attribute that enables geolocation, microphone, and camera access.

--- a/src/extensions/extra/JavaScriptCodeHints-Browser/npm-shrinkwrap.json
+++ b/src/extensions/extra/JavaScriptCodeHints-Browser/npm-shrinkwrap.json
@@ -1,120 +1,156 @@
 {
   "name": "brackets-javascript-code-hints",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "acorn": {
+  "packages": {
+    "": {
+      "name": "brackets-javascript-code-hints",
+      "hasInstallScript": true,
+      "dependencies": {
+        "acorn": "3.3.0",
+        "tern": "0.20.0"
+      }
+    },
+    "node_modules/acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "buffer-shims": {
+    "node_modules/buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
-    "core-util-is": {
+    "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "enhanced-resolve": {
+    "node_modules/enhanced-resolve": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-2.2.2.tgz",
       "integrity": "sha1-TaSU1ZEYMwi9RqlfW0DiVdydShY=",
-      "requires": {
+      "dependencies": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.3.0",
         "object-assign": "^4.0.1",
         "tapable": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=0.6"
       }
     },
-    "errno": {
+    "node_modules/errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "requires": {
+      "dependencies": {
         "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "cli.js"
       }
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "3.2.11",
       "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-      "requires": {
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dependencies": {
         "inherits": "2",
         "minimatch": "0.3"
       },
-      "dependencies": {
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
+      "engines": {
+        "node": "*"
       }
     },
-    "graceful-fs": {
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-      "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4="
+      "integrity": "sha1-UUw4dysxvuLgi+3CGgrrOr9UwZ4=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
-    "isarray": {
+    "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
-    "memory-fs": {
+    "node_modules/memory-fs": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
       "integrity": "sha1-e8xrYp46Q+hx1+Kaymrop/FcuyA=",
-      "requires": {
+      "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-      "requires": {
+      "deprecated": "Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue",
+      "dependencies": {
         "lru-cache": "2",
         "sigmund": "~1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "object-assign": {
+    "node_modules/object-assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
+      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "process-nextick-args": {
+    "node_modules/process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
-    "prr": {
+    "node_modules/prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
     },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
       "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-      "requires": {
+      "dependencies": {
         "buffer-shims": "^1.0.0",
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -124,39 +160,48 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "resolve-from": {
+    "node_modules/resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "sigmund": {
+    "node_modules/sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
-    "tapable": {
+    "node_modules/tapable": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.4.tgz",
-      "integrity": "sha1-p4FGBQidS6iWwzx+NWbhPc0ZSqU="
+      "integrity": "sha1-p4FGBQidS6iWwzx+NWbhPc0ZSqU=",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
-    "tern": {
+    "node_modules/tern": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/tern/-/tern-0.20.0.tgz",
       "integrity": "sha1-UFjhrhWhIaH0IVAM7QyFLBHm+zQ=",
-      "requires": {
+      "dependencies": {
         "acorn": "^3.2.0",
         "enhanced-resolve": "^2.2.2",
         "glob": "3",
         "minimatch": "0.2",
         "resolve-from": "2.0.0"
+      },
+      "bin": {
+        "tern": "bin/tern"
       }
     },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -56,23 +56,6 @@ define(function (require, exports, module) {
         }, callback);
     };
 
-    HTMLRewriter.prototype.injectCSP = function(callback) {
-        var doc = this.doc;
-        var head = doc.head || doc.querySelector("head");
-        if(!head) {
-            head = doc.createElement("head");
-            doc.documentElement.insertBefore(head, doc.documentElement.firstChild);
-        }
-
-        var meta = doc.querySelector('meta[http-equiv="Content-Security-Policy"]') ||
-                   doc.createElement("meta");
-        meta.setAttribute("http-equiv", "Content-Security-Policy");
-        meta.setAttribute("content", "connect-src blob:;");
-        head.insertBefore(meta, head.firstChild);
-
-        callback();
-    };
-
     HTMLRewriter.prototype.styles = function(callback) {
         var path = this.path;
         var elements = this.doc.querySelectorAll("style");
@@ -214,7 +197,6 @@ define(function (require, exports, module) {
         }
 
         Async.series([
-            iterator("injectCSP"),
             iterator("styles"),
             iterator("styleAttributes"),
             iterator("elements", "iframe", "src"),

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -56,6 +56,23 @@ define(function (require, exports, module) {
         }, callback);
     };
 
+    HTMLRewriter.prototype.injectCSP = function(callback) {
+        var doc = this.doc;
+        var head = doc.head || doc.querySelector("head");
+        if(!head) {
+            head = doc.createElement("head");
+            doc.documentElement.insertBefore(head, doc.documentElement.firstChild);
+        }
+
+        var meta = doc.querySelector('meta[http-equiv="Content-Security-Policy"]') ||
+                   doc.createElement("meta");
+        meta.setAttribute("http-equiv", "Content-Security-Policy");
+        meta.setAttribute("content", "connect-src blob:;");
+        head.insertBefore(meta, head.firstChild);
+
+        callback();
+    };
+
     HTMLRewriter.prototype.styles = function(callback) {
         var path = this.path;
         var elements = this.doc.querySelectorAll("style");
@@ -197,6 +214,7 @@ define(function (require, exports, module) {
         }
 
         Async.series([
+            iterator("injectCSP"),
             iterator("styles"),
             iterator("styleAttributes"),
             iterator("elements", "iframe", "src"),

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -56,6 +56,22 @@ define(function (require, exports, module) {
         }, callback);
     };
 
+    HTMLRewriter.prototype.injectCSP = function(callback) {
+        var doc = this.doc;
+        var head = doc.head || doc.querySelector("head");
+        if(!head) {
+            head = doc.createElement("head");
+            doc.documentElement.insertBefore(head, doc.documentElement.firstChild);
+        }
+
+        var meta = doc.createElement("meta");
+        meta.setAttribute("http-equiv", "Content-Security-Policy");
+        meta.setAttribute("content", "connect-src blob:;");
+        head.insertBefore(meta, head.firstChild);
+
+        callback();
+    };
+
     HTMLRewriter.prototype.styles = function(callback) {
         var path = this.path;
         var elements = this.doc.querySelectorAll("style");
@@ -197,6 +213,7 @@ define(function (require, exports, module) {
         }
 
         Async.series([
+            iterator("injectCSP"),
             iterator("styles"),
             iterator("styleAttributes"),
             iterator("elements", "iframe", "src"),

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -64,7 +64,8 @@ define(function (require, exports, module) {
             doc.documentElement.insertBefore(head, doc.documentElement.firstChild);
         }
 
-        var meta = doc.createElement("meta");
+        var meta = doc.querySelector('meta[http-equiv="Content-Security-Policy"]') ||
+                   doc.createElement("meta");
         meta.setAttribute("http-equiv", "Content-Security-Policy");
         meta.setAttribute("content", "connect-src blob:;");
         head.insertBefore(meta, head.firstChild);

--- a/src/npm-shrinkwrap.json
+++ b/src/npm-shrinkwrap.json
@@ -1,374 +1,483 @@
 {
   "name": "brackets-src",
+  "lockfileVersion": 3,
   "requires": true,
-  "lockfileVersion": 1,
-  "dependencies": {
-    "ansi-regex": {
+  "packages": {
+    "": {
+      "name": "brackets-src",
+      "dependencies": {
+        "codemirror": "5.21.0",
+        "less": "2.7.2"
+      }
+    },
+    "node_modules/ansi-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "asap": {
+    "node_modules/asap": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
       "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
       "optional": true
     },
-    "asn1": {
+    "node_modules/asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
       "optional": true
     },
-    "assert-plus": {
+    "node_modules/assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
-    "asynckit": {
+    "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "optional": true
     },
-    "aws-sign2": {
+    "node_modules/aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "aws4": {
+    "node_modules/aws4": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
       "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
       "optional": true
     },
-    "bcrypt-pbkdf": {
+    "node_modules/bcrypt-pbkdf": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
       "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "tweetnacl": "^0.14.3"
       }
     },
-    "boom": {
+    "node_modules/boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "requires": {
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "optional": true,
+      "dependencies": {
         "hoek": "2.x.x"
+      },
+      "engines": {
+        "node": ">=0.10.40"
       }
     },
-    "caseless": {
+    "node_modules/caseless": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
       "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
       "optional": true
     },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "codemirror": {
+    "node_modules/codemirror": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.21.0.tgz",
       "integrity": "sha1-nsTK7aUIB1dbIRUia/EkFPhdIkY="
     },
-    "combined-stream": {
+    "node_modules/combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
+      "optional": true,
+      "dependencies": {
         "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "commander": {
+    "node_modules/commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "graceful-readlink": ">= 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
       }
     },
-    "cryptiles": {
+    "node_modules/cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "boom": "2.x.x"
+      },
+      "engines": {
+        "node": ">=0.10.40"
       }
     },
-    "dashdash": {
+    "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
       },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "optional": true
-        }
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "delayed-stream": {
+    "node_modules/dashdash/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "ecc-jsbn": {
+    "node_modules/ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "jsbn": "~0.1.0"
       }
     },
-    "errno": {
+    "node_modules/errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "cli.js"
       }
     },
-    "escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "extend": {
+    "node_modules/extend": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
       "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
       "optional": true
     },
-    "extsprintf": {
+    "node_modules/extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "optional": true
     },
-    "forever-agent": {
+    "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "form-data": {
+    "node_modules/form-data": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
       "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.5",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
-    "generate-function": {
+    "node_modules/generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "optional": true
     },
-    "generate-object-property": {
+    "node_modules/generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "is-property": "^1.0.0"
       }
     },
-    "getpass": {
+    "node_modules/getpass": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
       "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
       "optional": true,
-      "requires": {
-        "assert-plus": "^1.0.0"
-      },
       "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "optional": true
-        }
+        "assert-plus": "^1.0.0"
       }
     },
-    "graceful-fs": {
+    "node_modules/getpass/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "graceful-readlink": {
+    "node_modules/graceful-readlink": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "optional": true
     },
-    "har-validator": {
+    "node_modules/har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "deprecated": "this library is no longer supported",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "chalk": "^1.1.1",
         "commander": "^2.9.0",
         "is-my-json-valid": "^2.12.4",
         "pinkie-promise": "^2.0.0"
+      },
+      "bin": {
+        "har-validator": "bin/har-validator"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "has-ansi": {
+    "node_modules/has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "hawk": {
+    "node_modules/hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "deprecated": "This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "boom": "2.x.x",
         "cryptiles": "2.x.x",
         "hoek": "2.x.x",
         "sntp": "1.x.x"
+      },
+      "engines": {
+        "node": ">=0.10.32"
       }
     },
-    "hoek": {
+    "node_modules/hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.40"
+      }
     },
-    "http-signature": {
+    "node_modules/http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "assert-plus": "^0.2.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
-    "image-size": {
+    "node_modules/image-size": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.1.tgz",
       "integrity": "sha1-KO6oVIpLFENIDd3cHgg65UZSQ58=",
-      "optional": true
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "is-my-json-valid": {
+    "node_modules/is-my-json-valid": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
       "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+      "deprecated": "catastrophic backtracking in regexes could potentially lead to REDOS attack, upgrade to 2.17.2 as soon as possible",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "generate-function": "^2.0.0",
         "generate-object-property": "^1.1.0",
         "jsonpointer": "^4.0.0",
         "xtend": "^4.0.0"
       }
     },
-    "is-property": {
+    "node_modules/is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "optional": true
     },
-    "is-typedarray": {
+    "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "optional": true
     },
-    "isstream": {
+    "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "optional": true
     },
-    "jodid25519": {
+    "node_modules/jodid25519": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
       "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "jsbn": "~0.1.0"
       }
     },
-    "jsbn": {
+    "node_modules/jsbn": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
       "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
       "optional": true
     },
-    "json-schema": {
+    "node_modules/json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "optional": true
     },
-    "json-stringify-safe": {
+    "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "optional": true
     },
-    "jsonpointer": {
+    "node_modules/jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "jsprim": {
+    "node_modules/jsprim": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
       "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+      "engines": [
+        "node >=0.6.0"
+      ],
       "optional": true,
-      "requires": {
+      "dependencies": {
         "extsprintf": "1.0.2",
         "json-schema": "0.2.3",
         "verror": "1.3.6"
       }
     },
-    "less": {
+    "node_modules/less": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
-      "requires": {
+      "bin": {
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "optionalDependencies": {
         "errno": "^0.1.1",
         "graceful-fs": "^4.1.2",
         "image-size": "~0.5.0",
@@ -379,94 +488,122 @@
         "source-map": "^0.5.3"
       }
     },
-    "mime": {
+    "node_modules/mime": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-      "optional": true
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.25.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
+      "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
       "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-      "requires": {
+      "optional": true,
+      "dependencies": {
         "mime-db": "~1.25.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimist": {
+    "node_modules/minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "optional": true
     },
-    "mkdirp": {
+    "node_modules/mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
-    "oauth-sign": {
+    "node_modules/oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "pinkie": {
+    "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "pinkie-promise": {
+    "node_modules/pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "promise": {
+    "node_modules/promise": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "asap": "~2.0.3"
       }
     },
-    "prr": {
+    "node_modules/prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
       "optional": true
     },
-    "punycode": {
+    "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
       "optional": true
     },
-    "qs": {
+    "node_modules/qs": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
       "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
     },
-    "request": {
+    "node_modules/request": {
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "aws-sign2": "~0.6.0",
         "aws4": "^1.2.1",
         "caseless": "~0.11.0",
@@ -487,110 +624,153 @@
         "tough-cookie": "~2.3.0",
         "tunnel-agent": "~0.4.1",
         "uuid": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
-    "sntp": {
+    "node_modules/sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "deprecated": "This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "hoek": "2.x.x"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
-    "source-map": {
+    "node_modules/source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "sshpk": {
+    "node_modules/sshpk": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
       "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
         "dashdash": "^1.12.0",
+        "getpass": "^0.1.1"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "optionalDependencies": {
+        "bcrypt-pbkdf": "^1.0.0",
         "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
         "jodid25519": "^1.0.0",
         "jsbn": "~0.1.0",
         "tweetnacl": "~0.14.0"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "optional": true
-        }
       }
     },
-    "stringstream": {
+    "node_modules/sshpk/node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
       "optional": true
     },
-    "strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
-    "tough-cookie": {
+    "node_modules/tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
-    "tunnel-agent": {
+    "node_modules/tunnel-agent": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
       "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "tweetnacl": {
+    "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
       "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-      "optional": true
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "verror": {
+    "node_modules/verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "engines": [
+        "node >=0.6.0"
+      ],
       "optional": true,
-      "requires": {
+      "dependencies": {
         "extsprintf": "1.0.2"
       }
     },
-    "xtend": {
+    "node_modules/xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }


### PR DESCRIPTION
~~This is a proposal to add a sandbox to the preview iframe. This will prevent any scripts from running on the Web Lab edit page (this does not cover view). It will also prevent anything else blocked by the sandbox (see [reference](https://www.w3schools.com/tags/att_iframe_sandbox.asp)). I had to add `allow-same-origin` for bramble to continue working. I asked curriculum if we use forms in CSD Unit 2 and we do not. If we run into issues we can always extend the sandbox to include other options, but I figured more restrictive was better.~~

This is a proposal to inject a restrictive content security policy into html pages. The content security policy prevents any connect-src besides a blob.

The relevant change here is in `HTMLRewriter.js`. The PR also includes some unrelated changes to get things working:
- I updated an else statement to do a null check because I was seeing console errors on my local instance of bramble
- I upgraded a package that was no longer working, which changed a bunch of build files.

## Testing story
I built and ran bramble locally using `npm start`  and also ran `npm run watch:api` to rebuild on changes. You can run bramble in isolation on localhost using this method (see the readme of this repo). I found you can also point web lab to your local bramble [here](https://github.com/code-dot-org/code-dot-org/blob/692d156e8d7cec1732f6dbe72cda7a9163db6c66/dashboard/app/controllers/weblab_host_controller.rb#L7), which I did. After this change, I can still run web lab projects, but any js does not run. I also tested that the preview still auto-refreshes, the inspector still works, and multiple page projects still work.

## Deployment Plan
If this is approved, I'll follow the steps in the readme to build a new version of bramble and upload it to S3, then update the web lab host controller accordingly.