### PR TITLE
Bump to v0.1.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@code-dot-org/bramble",
-    "version": "0.1.31",
+    "version": "0.1.32",
     "homepage": "https://github.com/code-dot-org/bramble",
     "repository": {
         "type": "git",


### PR DESCRIPTION
This bumps the bramble version to account for the changes added in #23. I've already made the bucket in S3 with this version's code that we will reference on the code-dot-org side.