### PR TITLE
Security Improvements

### DIFF
--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
@@ -119,6 +119,7 @@ define(function (require, exports, module) {
 
     /**
      * Returns the instrumented version of the file.
+     * @param {string} nonce CSP nonce to add to injected script tags.
      * @return {{body: string}} instrumented doc
      */
     LiveHTMLDocument.prototype.getResponseData = function (nonce) {

--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
@@ -121,10 +121,10 @@ define(function (require, exports, module) {
      * Returns the instrumented version of the file.
      * @return {{body: string}} instrumented doc
      */
-    LiveHTMLDocument.prototype.getResponseData = function (enabled) {
+    LiveHTMLDocument.prototype.getResponseData = function (enabled, nonce) {
         var body;
         if (this._instrumentationEnabled) {
-            body = HTMLInstrumentation.generateInstrumentedHTML(this.editor, this.protocol.getRemoteScript());
+            body = HTMLInstrumentation.generateInstrumentedHTML(this.editor, this.protocol.getRemoteScript(nonce));
         }
 
         return {

--- a/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/documents/LiveHTMLDocument.js
@@ -121,7 +121,7 @@ define(function (require, exports, module) {
      * Returns the instrumented version of the file.
      * @return {{body: string}} instrumented doc
      */
-    LiveHTMLDocument.prototype.getResponseData = function (enabled, nonce) {
+    LiveHTMLDocument.prototype.getResponseData = function (nonce) {
         var body;
         if (this._instrumentationEnabled) {
             body = HTMLInstrumentation.generateInstrumentedHTML(this.editor, this.protocol.getRemoteScript(nonce));

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -198,6 +198,7 @@ define(function (require, exports, module) {
      * Returns a script that should be injected into the HTML that's launched in the
      * browser in order to implement remote commands that handle protocol requests.
      * Includes the <script> tags.
+     * @param {string} nonce CSP nonce to add to the injected script tag.
      * @return {string}
      */
     function getRemoteFunctionsScript(nonce) {
@@ -214,6 +215,7 @@ define(function (require, exports, module) {
      * Returns a script that should be injected into the HTML that's launched in the
      * browser in order to handle protocol requests. Includes the <script> tags.
      * This script will also include the script required by the transport, if any.
+     * @param {string} nonce CSP nonce to add to the injected script tags.
      * @return {string}
      */
     function getRemoteScript(nonce) {

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/LiveDevProtocol.js
@@ -200,13 +200,14 @@ define(function (require, exports, module) {
      * Includes the <script> tags.
      * @return {string}
      */
-    function getRemoteFunctionsScript() {
+    function getRemoteFunctionsScript(nonce) {
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
         var script = "";
         // Inject DocumentObserver into the browser (tracks related documents)
         script += DocumentObserver;
         // Inject remote functions into the browser.
         script += "window._LD=(" + RemoteFunctions + "())";
-        return "<script>\n" + script + "</script>\n";
+        return "<script" + nonceAttr + ">\n" + script + "</script>\n";
     }
 
     /**
@@ -215,11 +216,12 @@ define(function (require, exports, module) {
      * This script will also include the script required by the transport, if any.
      * @return {string}
      */
-    function getRemoteScript() {
-        var transportScript = _transport.getRemoteScript() || "";
-        var remoteFunctionsScript = getRemoteFunctionsScript() || "";
+    function getRemoteScript(nonce) {
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
+        var transportScript = _transport.getRemoteScript(null, nonce) || "";
+        var remoteFunctionsScript = getRemoteFunctionsScript(nonce) || "";
         return transportScript +
-            "<script>\n" + LiveDevProtocolRemote + "</script>\n" +
+            "<script" + nonceAttr + ">\n" + LiveDevProtocolRemote + "</script>\n" +
             remoteFunctionsScript;
     }
 

--- a/src/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.js
@@ -50,8 +50,9 @@ define(function (require, exports, module) {
      * Returns the script that should be injected into the browser to handle the other end of the transport.
      * @return {string}
      */
-    function getRemoteScript() {
-        return "<script>\n" +
+    function getRemoteScript(path, nonce) {
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
+        return "<script" + nonceAttr + ">\n" +
             NodeSocketTransportRemote +
             "this._Brackets_LiveDev_Socket_Transport_URL = 'ws://localhost:" + SOCKET_PORT + "';\n" +
             "</script>\n";

--- a/src/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/transports/NodeSocketTransport.js
@@ -48,6 +48,8 @@ define(function (require, exports, module) {
 
     /**
      * Returns the script that should be injected into the browser to handle the other end of the transport.
+     * @param {string} path Unused.
+     * @param {string} nonce CSP nonce to add to the injected script tag.
      * @return {string}
      */
     function getRemoteScript(path, nonce) {

--- a/src/extensions/default/bramble/lib/ConsoleManager.js
+++ b/src/extensions/default/bramble/lib/ConsoleManager.js
@@ -4,8 +4,9 @@ define(function (require, exports, module) {
     var ConsoleInterfaceManager = require("lib/ConsoleInterfaceManager"),
         ConsoleManagerRemote = require("text!lib/ConsoleManagerRemote.js");
 
-    function getRemoteScript() {
-        return "<script>\n" + ConsoleManagerRemote + "</script>\n";
+    function getRemoteScript(nonce) {
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
+        return "<script" + nonceAttr + ">\n" + ConsoleManagerRemote + "</script>\n";
     }
 
     function isConsoleRequest(msg) {

--- a/src/extensions/default/bramble/lib/LinkManager.js
+++ b/src/extensions/default/bramble/lib/LinkManager.js
@@ -9,9 +9,10 @@ define(function (require, exports, module) {
 
     var LinkManagerRemote = require("text!lib/LinkManagerRemote.js");
 
-    function getRemoteScript() {
+    function getRemoteScript(nonce) {
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
         // Intercept clicks on <a> in the preview document
-        return "<script>\n" + LinkManagerRemote + "</script>\n";
+        return "<script" + nonceAttr + ">\n" + LinkManagerRemote + "</script>\n";
     }
 
     function getNavigationPath(message) {

--- a/src/extensions/default/bramble/lib/MouseManager.js
+++ b/src/extensions/default/bramble/lib/MouseManager.js
@@ -212,12 +212,13 @@ define(function (require, exports, module) {
         _prevLineMarker = codeMirror.markText(from, to, { className: "bramble-inspector-highlight" });
     }
 
-    function getRemoteScript(filename) {
+    function getRemoteScript(filename, nonce) {
         filename = filename || "unknown";
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
 
         // Track scroll position per filename, so you can be at different points in each doc
-        return "<script>window.___brambleFilename = '" + filename + "';</script>\n" +
-               "<script>\n" + MouseManagerRemote + "</script>\n";
+        return "<script" + nonceAttr + ">window.___brambleFilename = '" + filename + "';</script>\n" +
+               "<script" + nonceAttr + ">\n" + MouseManagerRemote + "</script>\n";
     }
 
     exports.enableInspector = enableInspector;

--- a/src/extensions/default/bramble/lib/PostMessageTransport.js
+++ b/src/extensions/default/bramble/lib/PostMessageTransport.js
@@ -238,17 +238,18 @@ define(function (require, exports, module) {
      * @param {string} path (Optional) a path being served, or the current LiveDoc's path if missing.
      * @return {string}
      */
-    function getRemoteScript(path) {
+    function getRemoteScript(path, nonce) {
         var currentDoc = LiveDevMultiBrowser._getCurrentLiveDoc();
         var currentPath = path || (currentDoc && currentDoc.doc.file.fullPath);
         var escapedPath = escapedPathTemplate({path: currentPath});
+        var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
 
         return '<base href="' + UrlCache.getBaseUrl() + '">\n' +
-            "<script>\n" + PostMessageTransportRemote + "</script>\n" +
-            XHRManager.getRemoteScript() +
-            MouseManager.getRemoteScript(escapedPath) +
-            LinkManager.getRemoteScript() +
-            ConsoleManager.getRemoteScript();
+            "<script" + nonceAttr + ">\n" + PostMessageTransportRemote + "</script>\n" +
+            XHRManager.getRemoteScript(nonce) +
+            MouseManager.getRemoteScript(escapedPath, nonce) +
+            LinkManager.getRemoteScript(nonce) +
+            ConsoleManager.getRemoteScript(nonce);
     }
 
     // URL of document being rewritten/launched (if any)

--- a/src/extensions/default/bramble/lib/XHRManager.js
+++ b/src/extensions/default/bramble/lib/XHRManager.js
@@ -9,10 +9,11 @@ define(function (require, exports, module) {
 
     var XHRManagerRemote = require("text!lib/XHRManagerRemote.js");
 
-    function getRemoteScript() {
+    function getRemoteScript(nonce) {
         // Intercept XHR requests, but only if we're rewriting URLs (e.g., Blob URLs)
         if(UrlCache.getShouldRewriteUrls()) {
-            return "<script>\n" + XHRManagerRemote + "</script>\n";
+            var nonceAttr = nonce ? ' nonce="' + nonce + '"' : '';
+            return "<script" + nonceAttr + ">\n" + XHRManagerRemote + "</script>\n";
         }
         return "";
     }

--- a/src/extensions/default/bramble/lib/iframe-browser.js
+++ b/src/extensions/default/bramble/lib/iframe-browser.js
@@ -43,7 +43,8 @@ define(function (require, exports, module) {
         // Create the iFrame for the blob to live in later
         var iframeConfig = {
             id: "bramble-iframe-browser",
-            frameborder: 0
+            frameborder: 0,
+            sandbox: 'allow-forms allow-same-origin allow-scripts'
         };
 
         // CDO-Bramble: Upstream includes an 'allow' attribute that enables geolocation, microphone, and camera access.

--- a/src/extensions/default/bramble/nohost/HTMLServer.js
+++ b/src/extensions/default/bramble/nohost/HTMLServer.js
@@ -1,5 +1,5 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, brackets */
+/*global define, brackets, crypto, Uint8Array */
 define(function (require, exports, module) {
     "use strict";
 
@@ -18,6 +18,14 @@ define(function (require, exports, module) {
         LinkManager             = require("lib/LinkManager");
 
     var _shouldUseBlobURL;
+
+    function generateNonce() {
+        var array = new Uint8Array(16);
+        crypto.getRandomValues(array);
+        return Array.prototype.map.call(array, function(b) {
+            return ("0" + b.toString(16)).slice(-2);
+        }).join("");
+    }
 
     function _isHTML(path) {
         return LiveDevelopmentUtils.isStaticHtmlFileExt(path);
@@ -116,8 +124,8 @@ define(function (require, exports, module) {
             });
         }
 
-        function serveHTML(path, html, server, callback) {
-            HTMLRewriter.rewrite(path, html, server, function(err, html) {
+        function serveHTML(path, html, server, nonce, callback) {
+            HTMLRewriter.rewrite(path, html, server, nonce, function(err, html) {
                 if(err) {
                     callback(err);
                     return;
@@ -139,9 +147,11 @@ define(function (require, exports, module) {
             });
         }
 
+        var nonce = generateNonce();
+
         function serve(body) {
             if(_isHTML(path)) {
-                serveHTML(path, body, server, callback);
+                serveHTML(path, body, server, nonce, callback);
             } else if (_isCSS(path)) {
                 serveCSS(path, body, callback);
             } else {
@@ -151,7 +161,7 @@ define(function (require, exports, module) {
 
         // Prefer the LiveDoc, but use what's on disk if we have to
         if(liveDocument) {
-            return serve(liveDocument.getResponseData().body);
+            return serve(liveDocument.getResponseData(nonce).body);
         }
 
         FilerUtils
@@ -164,7 +174,7 @@ define(function (require, exports, module) {
 
                 // Since we don't have a LiveDoc (yet) and aren't instrumenting fully,
                 // at least inject the necessary remote scripts so preview APIs work.
-                var scripts = PostMessageTransport.getRemoteScript(path);
+                var scripts = PostMessageTransport.getRemoteScript(path, nonce);
                 var scriptsWithEndTag = scripts + "$&";
                 var headRegex = new RegExp(/<\/\s*head>/);
                 var htmlRegex = new RegExp(/<\/\s*html>/);

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -1,5 +1,5 @@
 /*jslint vars: true, plusplus: true, devel: true, nomen: true, regexp: true, indent: 4, maxerr: 50 */
-/*global define, DOMParser, XMLSerializer */
+/*global define, DOMParser, XMLSerializer, crypto, Uint8Array */
 define(function (require, exports, module) {
     "use strict";
 
@@ -18,14 +18,23 @@ define(function (require, exports, module) {
      */
     var jsEnabledOverride = false;
 
+    function generateNonce() {
+        var array = new Uint8Array(16);
+        crypto.getRandomValues(array);
+        return Array.prototype.map.call(array, function(b) {
+            return ("0" + b.toString(16)).slice(-2);
+        }).join("");
+    }
+
     /**
      * Rewrite all external resources (links, scripts, img sources, ...) to
      * blob URL Objects from the fs.
      */
-    function HTMLRewriter(path, html, server) {
+    function HTMLRewriter(path, html, server, nonce) {
         this.path = path;
         this.dir = Path.dirname(path);
         this.server = server;
+        this.nonce = nonce || generateNonce();
 
         // Turn this html into a DOM, process it
         var parser = new DOMParser();
@@ -67,7 +76,7 @@ define(function (require, exports, module) {
         var meta = doc.querySelector('meta[http-equiv="Content-Security-Policy"]') ||
                    doc.createElement("meta");
         meta.setAttribute("http-equiv", "Content-Security-Policy");
-        meta.setAttribute("content", "connect-src blob:;");
+        meta.setAttribute("content", "script-src 'nonce-" + this.nonce + "'; connect-src blob:;");
         head.insertBefore(meta, head.firstChild);
 
         callback();
@@ -179,10 +188,14 @@ define(function (require, exports, module) {
         callback();
     };
 
-    function rewrite(path, html, server, callback) {
+    function rewrite(path, html, server, nonce, callback) {
         if(typeof server === "function") {
             callback = server;
             server = null;
+            nonce = null;
+        } else if(typeof nonce === "function") {
+            callback = nonce;
+            nonce = null;
         }
         // We may or may not have a server for rewriting live CSS docs in <link>s (e.g.,
         // when we `fs.writeFile()` and generate cached Blob URLs in `handleFile()`).
@@ -202,7 +215,7 @@ define(function (require, exports, module) {
             return callback(null, html);
         }
 
-        var rewriter = new HTMLRewriter(path, html, server);
+        var rewriter = new HTMLRewriter(path, html, server, nonce);
 
         function iterator(functionName) {
             var args = Array.prototype.slice.call(arguments, 1);

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -82,6 +82,14 @@ define(function (require, exports, module) {
         callback();
     };
 
+    HTMLRewriter.prototype.stripMetaRefresh = function(callback) {
+        var elements = this.doc.querySelectorAll('meta[http-equiv="refresh"], meta[http-equiv="Refresh"]');
+        Array.prototype.forEach.call(elements, function(element) {
+            element.parentNode.removeChild(element);
+        });
+        callback();
+    };
+
     HTMLRewriter.prototype.styles = function(callback) {
         var path = this.path;
         var elements = this.doc.querySelectorAll("style");
@@ -228,6 +236,7 @@ define(function (require, exports, module) {
 
         Async.series([
             iterator("injectCSP"),
+            iterator("stripMetaRefresh"),
             iterator("styles"),
             iterator("styleAttributes"),
             iterator("elements", "iframe", "src"),

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
         var meta = doc.querySelector('meta[http-equiv="Content-Security-Policy"]') ||
                    doc.createElement("meta");
         meta.setAttribute("http-equiv", "Content-Security-Policy");
-        meta.setAttribute("content", "script-src 'nonce-" + this.nonce + "'; connect-src blob:;");
+        meta.setAttribute("content", "script-src 'nonce-" + this.nonce + "' 'unsafe-eval'; connect-src blob:;");
         head.insertBefore(meta, head.firstChild);
 
         callback();

--- a/src/filesystem/impls/filer/lib/HTMLRewriter.js
+++ b/src/filesystem/impls/filer/lib/HTMLRewriter.js
@@ -76,7 +76,7 @@ define(function (require, exports, module) {
         var meta = doc.querySelector('meta[http-equiv="Content-Security-Policy"]') ||
                    doc.createElement("meta");
         meta.setAttribute("http-equiv", "Content-Security-Policy");
-        meta.setAttribute("content", "script-src 'nonce-" + this.nonce + "' 'unsafe-eval'; connect-src blob:;");
+        meta.setAttribute("content", "script-src 'nonce-" + this.nonce + "' 'unsafe-eval'; connect-src blob:; frame-src blob:; object-src 'none';");
         head.insertBefore(meta, head.firstChild);
 
         callback();


### PR DESCRIPTION
This PR locks down the content security policy on the bramble iframe further, and adds a sandbox.
Rough details:
- Changed from `connect-src: blob:` to `connect-src blob:; frame-src blob:; object-src 'none';`. Additionally set script-src to a uniquely-generated nonce plus `'unsafe-eval'`. That nonce is used to identify the scripts bramble needs without allowing other scripts to execute. 
- Added a sandbox to the iframe. It's pretty permissive because the csp blocks much of what we need, but it provides some further security.

Further discussion on [slack](https://codedotorg.slack.com/archives/C0AP4AULFV0/p1775678761831789).

## Testing
I tested that the inspector, linking between files, and live updates still work with these changes.